### PR TITLE
feat: add entire screen capture support + stop icon on menu bar

### DIFF
--- a/EasyDemo/Models/CaptureSource.swift
+++ b/EasyDemo/Models/CaptureSource.swift
@@ -1,0 +1,62 @@
+import Foundation
+import CoreGraphics
+import ScreenCaptureKit
+
+/// Represents information about a macOS display
+struct DisplayInfo: Identifiable, Hashable {
+    let id: CGDirectDisplayID
+    let width: Int
+    let height: Int
+    let scDisplay: SCDisplay?
+
+    var displayName: String {
+        if CGDisplayIsMain(id) != 0 {
+            return "Main Display (\(width) x \(height))"
+        }
+        return "Display (\(width) x \(height))"
+    }
+
+    var bounds: CGRect {
+        CGRect(x: 0, y: 0, width: width, height: height)
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    static func == (lhs: DisplayInfo, rhs: DisplayInfo) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+/// Represents the source to capture: either a window or an entire display
+enum CaptureSource: Identifiable, Hashable {
+    case window(WindowInfo)
+    case display(DisplayInfo)
+
+    var id: String {
+        switch self {
+        case .window(let info): return "window-\(info.id)"
+        case .display(let info): return "display-\(info.id)"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .window(let info): return info.displayName
+        case .display(let info): return info.displayName
+        }
+    }
+
+    var bounds: CGRect {
+        switch self {
+        case .window(let info): return info.bounds
+        case .display(let info): return info.bounds
+        }
+    }
+
+    var isDisplay: Bool {
+        if case .display = self { return true }
+        return false
+    }
+}

--- a/EasyDemo/Models/RecordingConfiguration.swift
+++ b/EasyDemo/Models/RecordingConfiguration.swift
@@ -3,7 +3,7 @@ import CoreGraphics
 import AVFoundation
 
 struct RecordingConfiguration {
-    let window: WindowInfo
+    let source: CaptureSource
     let background: BackgroundStyle
     let webcam: WebcamConfiguration
     let audio: AudioConfiguration
@@ -55,7 +55,7 @@ struct RecordingConfiguration {
     }
 
     static func `default`(
-        window: WindowInfo,
+        source: CaptureSource,
         background: BackgroundStyle,
         webcam: WebcamConfiguration,
         audio: AudioConfiguration = .default,
@@ -83,7 +83,7 @@ struct RecordingConfiguration {
         let outputURL = baseDirectory.appendingPathComponent(filename)
 
         return RecordingConfiguration(
-            window: window,
+            source: source,
             background: background,
             webcam: webcam,
             audio: audio,

--- a/EasyDemo/Services/RecordingEngine.swift
+++ b/EasyDemo/Services/RecordingEngine.swift
@@ -6,9 +6,12 @@ import Combine
 
 @MainActor
 class RecordingEngine: NSObject, ObservableObject, SCStreamOutput {
+    static let shared = RecordingEngine()
+
     @Published var isRecording = false
     @Published var recordingDuration: TimeInterval = 0
     @Published var error: Error?
+    @Published var lastRecordingResult: RecordingResult?
 
     private var stream: SCStream?
     private var assetWriter: AVAssetWriter?
@@ -84,6 +87,8 @@ class RecordingEngine: NSObject, ObservableObject, SCStreamOutput {
             let currentTime = CMTime(seconds: CACurrentMediaTime(), preferredTimescale: 600)
             self.recordingDuration = CMTimeGetSeconds(CMTimeSubtract(currentTime, startTime))
         }
+
+        StatusBarManager.shared.show()
     }
 
     func stopRecording() async -> RecordingResult? {
@@ -125,18 +130,20 @@ class RecordingEngine: NSObject, ObservableObject, SCStreamOutput {
 
         let fileSize = getFileSize(at: url)
 
-        return RecordingResult(
+        let result = RecordingResult(
             fileURL: url,
             duration: finalDuration,
             fileSize: fileSize,
             timestamp: Date()
         )
+        self.lastRecordingResult = result
+        return result
     }
 
     private func cleanup() {
         // Stop accessing security-scoped resource
         outputDirectoryManager?.stopAccessing()
-        
+
         self.stream = nil
         self.assetWriter = nil
         self.videoInput = nil
@@ -145,6 +152,8 @@ class RecordingEngine: NSObject, ObservableObject, SCStreamOutput {
         self.startTime = nil
         self.isRecording = false
         self.outputDirectoryManager = nil
+
+        StatusBarManager.shared.hide()
     }
 
     private func getFileSize(at url: URL) -> Int64 {

--- a/EasyDemo/Services/RecordingEngine.swift
+++ b/EasyDemo/Services/RecordingEngine.swift
@@ -49,15 +49,29 @@ class RecordingEngine: NSObject, ObservableObject, SCStreamOutput {
         }
 
         let content = try await SCShareableContent.current
-        guard let scWindow = content.windows.first(where: { $0.windowID == configuration.window.id }) else {
-            throw RecordingError.windowNotFound
+        let filter: SCContentFilter
+
+        switch configuration.source {
+        case .window(let windowInfo):
+            guard let scWindow = content.windows.first(where: { $0.windowID == windowInfo.id }) else {
+                throw RecordingError.windowNotFound
+            }
+            filter = SCContentFilter(desktopIndependentWindow: scWindow)
+
+        case .display(let displayInfo):
+            guard let scDisplay = content.displays.first(where: { $0.displayID == displayInfo.id }) else {
+                throw RecordingError.displayNotFound
+            }
+            filter = SCContentFilter(display: scDisplay, excludingWindows: [])
         }
 
-        let filter = SCContentFilter(desktopIndependentWindow: scWindow)
         self.captureScaleFactor = CGFloat(filter.pointPixelScale)
 
-        // Setup asset writer - this starts the recording session and sets self.startTime
+        // Setup asset writer
         try setupAssetWriter(configuration: configuration)
+
+        // Set startTime right before captures begin to minimize offset
+        self.startTime = CMTime(seconds: CACurrentMediaTime(), preferredTimescale: 600)
 
         // Start microphone/audio capture if enabled
         if configuration.audio.microphoneEnabled {
@@ -216,8 +230,7 @@ class RecordingEngine: NSObject, ObservableObject, SCStreamOutput {
         writer.startWriting()
         // Start session at time zero - samples will have timestamps relative to this
         writer.startSession(atSourceTime: .zero)
-        // Store the actual wall clock time when we started for timestamp calculations
-        self.startTime = CMTime(seconds: CACurrentMediaTime(), preferredTimescale: 600)
+        // startTime is set later in startRecording(), right before captures begin
     }
 
     private func calculateOutputSize(configuration: RecordingConfiguration) -> CGSize {
@@ -225,8 +238,10 @@ class RecordingEngine: NSObject, ObservableObject, SCStreamOutput {
             return resolution
         }
 
-        let windowPixelWidth = configuration.window.bounds.width * captureScaleFactor
-        let windowPixelHeight = configuration.window.bounds.height * captureScaleFactor
+        let sourceBounds = configuration.source.bounds
+
+        let windowPixelWidth = sourceBounds.width * captureScaleFactor
+        let windowPixelHeight = sourceBounds.height * captureScaleFactor
         let marginInPixels = UIConstants.Padding.minimum * 2 * captureScaleFactor
 
         return CGSize(
@@ -320,6 +335,16 @@ class RecordingEngine: NSObject, ObservableObject, SCStreamOutput {
             return
         }
 
+        // Capture timestamp BEFORE composition to avoid drift from processing time
+        let currentTime = CMTime(seconds: CACurrentMediaTime(), preferredTimescale: 600)
+        let presentationTime: CMTime
+
+        if let startTime = startTime {
+            presentationTime = CMTimeSubtract(currentTime, startTime)
+        } else {
+            presentationTime = .zero
+        }
+
         let composedBuffer = videoComposer.composeFrame(
             windowBuffer: imageBuffer,
             configuration: configuration,
@@ -330,16 +355,6 @@ class RecordingEngine: NSObject, ObservableObject, SCStreamOutput {
         )
 
         if let buffer = composedBuffer {
-            // Convert timestamp to be relative to recording start time
-            let currentTime = CMTime(seconds: CACurrentMediaTime(), preferredTimescale: 600)
-            let presentationTime: CMTime
-
-            if let startTime = startTime {
-                presentationTime = CMTimeSubtract(currentTime, startTime)
-            } else {
-                presentationTime = .zero
-            }
-
             adaptor.append(buffer, withPresentationTime: presentationTime)
             frameCount += 1
         }
@@ -362,6 +377,7 @@ class RecordingEngine: NSObject, ObservableObject, SCStreamOutput {
     enum RecordingError: LocalizedError {
         case cannotAddVideoInput
         case windowNotFound
+        case displayNotFound
 
         var errorDescription: String? {
             switch self {
@@ -369,6 +385,8 @@ class RecordingEngine: NSObject, ObservableObject, SCStreamOutput {
                 return "Failed to add video input to asset writer"
             case .windowNotFound:
                 return "Selected window not found"
+            case .displayNotFound:
+                return "Selected display not found"
             }
         }
     }

--- a/EasyDemo/Services/RecordingEngine/VideoComposer.swift
+++ b/EasyDemo/Services/RecordingEngine/VideoComposer.swift
@@ -48,7 +48,8 @@ final class VideoComposer {
             canvasSize: CGSize(width: nativeWidth, height: nativeHeight),
             webcamFrame: webcamFrame,
             webcamConfig: configuration.webcam,
-            scaleFactor: scaleFactor
+            scaleFactor: scaleFactor,
+            applyCornerRadius: configuration.source.isDisplay
         )
 
         let finalComposited = upscaleIfNeeded(
@@ -104,15 +105,26 @@ final class VideoComposer {
         canvasSize: CGSize,
         webcamFrame: CIImage?,
         webcamConfig: WebcamConfiguration,
-        scaleFactor: CGFloat
+        scaleFactor: CGFloat,
+        applyCornerRadius: Bool = false
     ) -> CIImage {
         let windowScale = CGFloat(scale)
-        let scaledWindow = windowImage.transformed(
+        var scaledWindow = windowImage.transformed(
             by: CGAffineTransform(scaleX: windowScale, y: windowScale)
         )
 
         let scaledWidth = windowImage.extent.width * windowScale
         let scaledHeight = windowImage.extent.height * windowScale
+
+        // Apply rounded corners for display captures
+        if applyCornerRadius {
+            let cornerRadius = 10.0 * scaleFactor
+            scaledWindow = applyRoundedCorners(
+                to: scaledWindow,
+                cornerRadius: cornerRadius
+            )
+        }
+
         let xOffset = (canvasSize.width - scaledWidth) / 2
         let yOffset = (canvasSize.height - scaledHeight) / 2
         let centeredWindow = scaledWindow.transformed(
@@ -132,6 +144,62 @@ final class VideoComposer {
         }
 
         return composited
+    }
+
+    private func applyRoundedCorners(to image: CIImage, cornerRadius: CGFloat) -> CIImage {
+        let rect = image.extent
+        guard let mask = createRoundedRectMask(
+            size: rect.size,
+            cornerRadius: cornerRadius
+        ) else {
+            return image
+        }
+
+        let positionedMask = mask.transformed(
+            by: CGAffineTransform(translationX: rect.origin.x, y: rect.origin.y)
+        )
+        let clearBg = CIImage(color: CIColor.clear).cropped(to: rect)
+
+        return image.applyingFilter("CIBlendWithMask", parameters: [
+            "inputBackgroundImage": clearBg,
+            "inputMaskImage": positionedMask
+        ])
+    }
+
+    private func createRoundedRectMask(size: CGSize, cornerRadius: CGFloat) -> CIImage? {
+        let width = Int(size.width)
+        let height = Int(size.height)
+        guard width > 0, height > 0 else { return nil }
+
+        guard let ctx = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceGray(),
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        ) else { return nil }
+
+        let rect = CGRect(origin: .zero, size: size)
+
+        // Fill black (masked out)
+        ctx.setFillColor(gray: 0, alpha: 1)
+        ctx.fill(rect)
+
+        // Draw white rounded rect (visible area)
+        ctx.setFillColor(gray: 1, alpha: 1)
+        let path = CGPath(
+            roundedRect: rect,
+            cornerWidth: cornerRadius,
+            cornerHeight: cornerRadius,
+            transform: nil
+        )
+        ctx.addPath(path)
+        ctx.fillPath()
+
+        guard let cgImage = ctx.makeImage() else { return nil }
+        return CIImage(cgImage: cgImage)
     }
 
     private func upscaleIfNeeded(

--- a/EasyDemo/Services/WindowCapture.swift
+++ b/EasyDemo/Services/WindowCapture.swift
@@ -15,13 +15,12 @@ import ScreenCaptureKit
 @MainActor
 class WindowCapture: ObservableObject {
     @Published var availableWindows: [WindowInfo] = []
+    @Published var availableDisplays: [DisplayInfo] = []
     @Published var hasScreenRecordingPermission = false
     @Published var isCheckingPermission = true
 
     init() {
-        Task {
-            await checkScreenRecordingPermission()
-        }
+        // Permission check is handled by the caller (e.g. WindowSelectionViewModel)
     }
 
     /// Check if screen recording permission is granted (preflight only, no prompt)
@@ -89,6 +88,30 @@ class WindowCapture: ObservableObject {
             self.availableWindows = windows
         } catch {
             print("Failed to enumerate windows: \(error)")
+        }
+    }
+
+    /// Enumerate all connected displays
+    func enumerateDisplays() async {
+        guard hasScreenRecordingPermission else { return }
+
+        do {
+            let content = try await SCShareableContent.current
+            var displays: [DisplayInfo] = []
+
+            for display in content.displays {
+                let info = DisplayInfo(
+                    id: display.displayID,
+                    width: display.width,
+                    height: display.height,
+                    scDisplay: display
+                )
+                displays.append(info)
+            }
+
+            self.availableDisplays = displays
+        } catch {
+            print("Failed to enumerate displays: \(error)")
         }
     }
 

--- a/EasyDemo/Services/WindowPreview.swift
+++ b/EasyDemo/Services/WindowPreview.swift
@@ -88,6 +88,72 @@ class WindowPreview: NSObject, ObservableObject, SCStreamOutput {
         }
     }
 
+    /// Capture a single frame from a display for preview
+    func capturePreview(display: DisplayInfo) async {
+        guard !isCapturing else { return }
+        isCapturing = true
+
+        defer { isCapturing = false }
+
+        do {
+            let content = try await SCShareableContent.current
+
+            guard let scDisplay = content.displays.first(where: { $0.displayID == display.id }) else {
+                print("Display not found")
+                return
+            }
+
+            let filter = SCContentFilter(display: scDisplay, excludingWindows: [])
+
+            let config = SCStreamConfiguration()
+            config.width = Int(filter.contentRect.width * CGFloat(filter.pointPixelScale))
+            config.height = Int(filter.contentRect.height * CGFloat(filter.pointPixelScale))
+            config.pixelFormat = kCVPixelFormatType_32BGRA
+            config.showsCursor = false
+            config.captureResolution = .best
+            config.scalesToFit = false
+            config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+
+            let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+            self.stream = stream
+
+            try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: .main)
+
+            try await stream.startCapture()
+
+            let image = await withCheckedContinuation { continuation in
+                self.continuation = continuation
+
+                Task {
+                    try? await Task.sleep(nanoseconds: 5_000_000_000)
+                    if self.continuation != nil {
+                        self.continuation?.resume(returning: nil)
+                        self.continuation = nil
+                    }
+                }
+            }
+
+            try await stream.stopCapture()
+            self.stream = nil
+
+            if let image = image {
+                self.previewImage = image
+            }
+        } catch {
+            print("Failed to capture display preview: \(error)")
+        }
+    }
+
+    /// Capture a preview from a CaptureSource (dispatches to window or display method)
+    func capturePreview(source: CaptureSource) async {
+        switch source {
+        case .window(let windowInfo):
+            await capturePreview(window: windowInfo)
+        case .display(let displayInfo):
+            await capturePreview(display: displayInfo)
+        }
+    }
+
     // MARK: - SCStreamOutput
 
     func stream(

--- a/EasyDemo/Utils/StatusBarManager.swift
+++ b/EasyDemo/Utils/StatusBarManager.swift
@@ -1,0 +1,56 @@
+import AppKit
+
+@MainActor
+class StatusBarManager: NSObject {
+    static let shared = StatusBarManager()
+
+    private var statusItem: NSStatusItem?
+    private var durationTimer: Timer?
+
+    private override init() {
+        super.init()
+    }
+
+    func show() {
+        guard statusItem == nil else { return }
+
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        if let button = item.button {
+            let image = NSImage(systemSymbolName: "stop.circle", accessibilityDescription: "Stop Recording")
+            button.image = image
+            button.target = self
+            button.action = #selector(stopRecording)
+        }
+
+        self.statusItem = item
+
+        durationTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateDuration()
+            }
+        }
+    }
+
+    func hide() {
+        durationTimer?.invalidate()
+        durationTimer = nil
+
+        if let item = statusItem {
+            NSStatusBar.system.removeStatusItem(item)
+        }
+        statusItem = nil
+    }
+
+    private func updateDuration() {
+        let duration = RecordingEngine.shared.recordingDuration
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        statusItem?.button?.title = String(format: " %02d:%02d", minutes, seconds)
+    }
+
+    @objc private func stopRecording() {
+        Task {
+            await RecordingEngine.shared.stopRecording()
+        }
+    }
+}

--- a/EasyDemo/ViewModels/WindowSelectionViewModel.swift
+++ b/EasyDemo/ViewModels/WindowSelectionViewModel.swift
@@ -12,26 +12,62 @@ import Combine
 /// ViewModel for window selection screen
 @MainActor
 class WindowSelectionViewModel: ObservableObject {
+    enum CaptureMode: String, CaseIterable {
+        case windows = "Windows"
+        case screens = "Screens"
+    }
+
     @Published var selectedWindow: WindowInfo?
+    @Published var captureMode: CaptureMode = .windows
     @Published var isRefreshing = false
 
     let windowCapture = WindowCapture()
+    private var cancellables = Set<AnyCancellable>()
 
     init() {
+        // Forward windowCapture's published property changes to this ViewModel
+        // so SwiftUI observes nested ObservableObject updates
+        windowCapture.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        // Re-check permissions when the app becomes active (e.g. after returning from System Settings)
+        NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                Task {
+                    let hadPermission = self.windowCapture.hasScreenRecordingPermission
+                    await self.windowCapture.checkScreenRecordingPermission()
+                    if !hadPermission && self.windowCapture.hasScreenRecordingPermission {
+                        await self.refreshSources()
+                    }
+                }
+            }
+            .store(in: &cancellables)
+
         Task {
-            // Wait for permission check to complete first
             await windowCapture.checkScreenRecordingPermission()
-            // Then automatically load windows if permission is granted
             if windowCapture.hasScreenRecordingPermission {
-                await refreshWindows()
+                await refreshSources()
             }
         }
     }
 
-    func refreshWindows() async {
+    func refreshSources() async {
         isRefreshing = true
         await windowCapture.enumerateWindows()
+        await windowCapture.enumerateDisplays()
         isRefreshing = false
+    }
+
+    func requestPermissionAndLoadSources() async {
+        // Open System Settings directly instead of triggering the system dialog,
+        // which has a "Quit & Reopen" button that doesn't work with modal sheets.
+        PermissionManager.shared.openSystemSettings(for: .screenRecording)
     }
 
     func selectWindow(_ window: WindowInfo) {

--- a/EasyDemo/Views/SetupView.swift
+++ b/EasyDemo/Views/SetupView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 import UniformTypeIdentifiers
 import AppKit
 
-/// Main setup view orchestrating window selection, background choice, and preview
+/// Main setup view orchestrating source selection, background choice, and preview
 struct SetupView: View {
-    @State private var selectedWindow: WindowInfo?
+    @State private var selectedSource: CaptureSource?
     @State private var selectedBackground: BackgroundStyle = BackgroundStyle.defaultBigSur
     @State private var webcamConfig = WebcamConfiguration.default
     @State private var audioConfig = AudioConfiguration.default
@@ -36,6 +36,10 @@ struct SetupView: View {
         case output
     }
 
+    private var isDisplayCapture: Bool {
+        selectedSource?.isDisplay ?? false
+    }
+
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             // Sidebar with setup options
@@ -44,16 +48,29 @@ struct SetupView: View {
                 .toolbar(removing: .sidebarToggle)
         } detail: {
             // Main preview area
-            if let window = selectedWindow {
-                WindowPreviewView(
-                    window: window,
-                    backgroundStyle: selectedBackground,
-                    webcamConfig: webcamConfig,
-                    windowScale: windowScale
-                )
-                .id(window.id)  // Force recreation when window changes
-                .navigationTitle("Preview")
-                .toolbar(removing: .sidebarToggle)
+            if let source = selectedSource {
+                switch source {
+                case .window(let window):
+                    WindowPreviewView(
+                        window: window,
+                        backgroundStyle: selectedBackground,
+                        webcamConfig: webcamConfig,
+                        windowScale: windowScale
+                    )
+                    .id(source.id)
+                    .navigationTitle("Preview")
+                    .toolbar(removing: .sidebarToggle)
+                case .display(let display):
+                    DisplayPreviewView(
+                        display: display,
+                        backgroundStyle: selectedBackground,
+                        webcamConfig: webcamConfig,
+                        displayScale: windowScale
+                    )
+                    .id(source.id)
+                    .navigationTitle("Preview")
+                    .toolbar(removing: .sidebarToggle)
+                }
             } else {
                 emptyPreviewState
                     .toolbar(removing: .sidebarToggle)
@@ -76,14 +93,14 @@ struct SetupView: View {
     @ViewBuilder
     private var setupSidebar: some View {
         List {
-            Section("Window Selection") {
-                if let window = selectedWindow {
+            Section("Source Selection") {
+                if let source = selectedSource {
                     HStack {
                         VStack(alignment: .leading, spacing: 4) {
-                            Text(window.displayName)
+                            Text(source.displayName)
                                 .font(.headline)
 
-                            Text("\(Int(window.bounds.width)) × \(Int(window.bounds.height))")
+                            Text("\(Int(source.bounds.width)) x \(Int(source.bounds.height))")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }
@@ -97,15 +114,15 @@ struct SetupView: View {
                         .disabled(recordingEngine.isRecording)
                     }
                 } else {
-                    Button("Select Window") {
+                    Button("Select Source") {
                         showingWindowSelector = true
                     }
                     .disabled(recordingEngine.isRecording)
                 }
             }
 
-            if selectedWindow != nil {
-                Section("Window Size") {
+            if selectedSource != nil {
+                Section(isDisplayCapture ? "Display Scale" : "Window Size") {
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
                             Text("Scale:")
@@ -356,9 +373,9 @@ struct SetupView: View {
                         }
                     } else {
                         Button {
-                            if let window = selectedWindow {
+                            if let source = selectedSource {
                                 let config = RecordingConfiguration.default(
-                                    window: window,
+                                    source: source,
                                     background: selectedBackground,
                                     webcam: webcamConfig,
                                     audio: audioConfig,
@@ -382,7 +399,7 @@ struct SetupView: View {
                         } label: {
                             Label("Start Recording", systemImage: "record.circle")
                         }
-                        .disabled(selectedWindow == nil)
+                        .disabled(selectedSource == nil)
                     }
                 }
             }
@@ -392,7 +409,7 @@ struct SetupView: View {
         }
         .navigationTitle("Setup")
         .sheet(isPresented: $showingWindowSelector) {
-            WindowSelectorSheet(selectedWindow: $selectedWindow)
+            WindowSelectorSheet(selectedSource: $selectedSource)
         }
         .sheet(item: $recordingResult) { result in
             RecordingCompletedView(result: result, outputDirectoryManager: outputDirectoryManager)
@@ -424,11 +441,11 @@ struct SetupView: View {
                 .font(.system(size: 64))
                 .foregroundColor(.secondary)
 
-            Text("Select a window to preview")
+            Text("Select a source to preview")
                 .font(.title2)
                 .foregroundColor(.secondary)
 
-            Button("Choose Window") {
+            Button("Choose Source") {
                 showingWindowSelector = true
             }
             .buttonStyle(.borderedProminent)
@@ -440,7 +457,7 @@ struct SetupView: View {
         let seconds = Int(duration) % 60
         return String(format: "%02d:%02d", minutes, seconds)
     }
-    
+
     private func toggleSidebar() {
         withAnimation {
             if columnVisibility == .all {
@@ -452,17 +469,17 @@ struct SetupView: View {
     }
 }
 
-/// Sheet for window selection
+/// Sheet for source selection
 struct WindowSelectorSheet: View {
-    @Binding var selectedWindow: WindowInfo?
+    @Binding var selectedSource: CaptureSource?
     @Environment(\.dismiss) private var dismiss
-    @State private var tempSelection: WindowInfo?
+    @State private var tempSelection: CaptureSource?
 
     var body: some View {
         VStack(spacing: 0) {
             // Header
             HStack {
-                Text("Select Window")
+                Text("Select Source")
                     .font(.title2)
                     .fontWeight(.semibold)
 
@@ -481,8 +498,8 @@ struct WindowSelectorSheet: View {
 
             Divider()
 
-            // Window list
-            WindowSelectionView(selectedWindow: $tempSelection)
+            // Source list
+            WindowSelectionView(selectedSource: $tempSelection)
 
             Divider()
 
@@ -496,7 +513,7 @@ struct WindowSelectorSheet: View {
                 .keyboardShortcut(.cancelAction)
 
                 Button("Select") {
-                    selectedWindow = tempSelection
+                    selectedSource = tempSelection
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)

--- a/EasyDemo/Views/SetupView.swift
+++ b/EasyDemo/Views/SetupView.swift
@@ -24,7 +24,7 @@ struct SetupView: View {
     @State private var recordingResult: RecordingResult?
     @State private var showingFolderPicker = false
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
-    @StateObject private var recordingEngine = RecordingEngine()
+    @StateObject private var recordingEngine = RecordingEngine.shared
     @StateObject private var outputDirectoryManager = OutputDirectoryManager()
 
     enum SidebarSection: Hashable {
@@ -347,8 +347,7 @@ struct SetupView: View {
 
                             Button {
                                 Task {
-                                    let result = await recordingEngine.stopRecording()
-                                    recordingResult = result
+                                    await recordingEngine.stopRecording()
                                 }
                             } label: {
                                 Label("Stop Recording", systemImage: "stop.circle.fill")
@@ -410,6 +409,11 @@ struct SetupView: View {
                 }
             case .failure(let error):
                 print("Failed to select folder: \(error)")
+            }
+        }
+        .onChange(of: recordingEngine.lastRecordingResult?.id) {
+            if let result = recordingEngine.lastRecordingResult {
+                recordingResult = result
             }
         }
     }

--- a/EasyDemo/Views/WindowPreviewView.swift
+++ b/EasyDemo/Views/WindowPreviewView.swift
@@ -197,6 +197,173 @@ struct WindowPreviewView: View {
     }
 }
 
+/// Preview for display captures with background and scale
+struct DisplayPreviewView: View {
+    let display: DisplayInfo
+    let backgroundStyle: BackgroundStyle
+    let webcamConfig: WebcamConfiguration?
+    let displayScale: Double
+    @StateObject private var preview = WindowPreview()
+    @StateObject private var webcam = WebcamCapture()
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                // Background layer
+                backgroundView
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+
+                // Display preview layer
+                if let image = preview.previewImage {
+                    let imageSize = CGSize(width: image.width, height: image.height)
+                    let scaledSize = calculatePreviewSize(
+                        imageSize: imageSize,
+                        containerSize: geometry.size
+                    )
+
+                    Image(decorative: image, scale: 1.0)
+                        .resizable()
+                        .frame(width: scaledSize.width, height: scaledSize.height)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .shadow(
+                            color: .black.opacity(0.3),
+                            radius: 20,
+                            x: 0,
+                            y: 10
+                        )
+                } else {
+                    VStack(spacing: 16) {
+                        ProgressView()
+                            .scaleEffect(1.5)
+
+                        Text("Capturing display preview...")
+                            .font(.headline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                // Webcam overlay
+                if let config = webcamConfig, config.isEnabled {
+                    if webcam.isCapturing, let webcamFrame = webcam.currentFrame {
+                        let webcamPosition = calculateWebcamPosition(
+                            config: config,
+                            viewportSize: geometry.size,
+                            webcamSize: config.size,
+                            padding: UIConstants.Padding.large
+                        )
+                        WebcamOverlayView(
+                            frame: webcamFrame,
+                            shape: config.shape,
+                            size: config.size
+                        )
+                        .position(x: webcamPosition.x, y: webcamPosition.y)
+                    } else {
+                        let webcamPosition = calculateWebcamPosition(
+                            config: config,
+                            viewportSize: geometry.size,
+                            webcamSize: config.size,
+                            padding: UIConstants.Padding.large
+                        )
+                        Circle()
+                            .fill(Color.gray.opacity(0.3))
+                            .frame(width: config.size, height: config.size)
+                            .overlay(
+                                ProgressView()
+                                    .progressViewStyle(.circular)
+                                    .scaleEffect(0.6)
+                            )
+                            .position(x: webcamPosition.x, y: webcamPosition.y)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .clipped()
+        }
+        .task {
+            await preview.capturePreview(display: display)
+
+            if let config = webcamConfig, config.isEnabled {
+                try? await webcam.startCapture(deviceId: config.selectedDeviceId)
+            }
+        }
+        .onChange(of: webcamConfig?.isEnabled) { _, isEnabled in
+            if isEnabled == false {
+                webcam.stopCapture()
+            } else if isEnabled == true {
+                Task {
+                    try? await webcam.startCapture(deviceId: webcamConfig?.selectedDeviceId)
+                }
+            }
+        }
+        .onChange(of: webcamConfig?.selectedDeviceId) { _, _ in
+            Task {
+                try? await webcam.switchToDevice(deviceId: webcamConfig?.selectedDeviceId)
+            }
+        }
+        .onDisappear {
+            webcam.stopCapture()
+        }
+    }
+
+    private func calculatePreviewSize(imageSize: CGSize, containerSize: CGSize) -> CGSize {
+        let minMargin: CGFloat = 80
+        let availableWidth = containerSize.width - (minMargin * 2)
+        let availableHeight = containerSize.height - (minMargin * 2)
+
+        let widthScale = availableWidth / imageSize.width
+        let heightScale = availableHeight / imageSize.height
+        let fitScale = min(widthScale, heightScale, 1.0)
+
+        let scale = fitScale * displayScale
+        return CGSize(width: imageSize.width * scale, height: imageSize.height * scale)
+    }
+
+    private func calculateWebcamPosition(
+        config: WebcamConfiguration,
+        viewportSize: CGSize,
+        webcamSize: CGFloat,
+        padding: CGFloat
+    ) -> CGPoint {
+        let topLeftPosition = config.position.offset(
+            in: viewportSize,
+            webcamSize: webcamSize,
+            padding: padding
+        )
+        return CGPoint(
+            x: topLeftPosition.x + webcamSize / 2,
+            y: topLeftPosition.y + webcamSize / 2
+        )
+    }
+
+    @ViewBuilder
+    private var backgroundView: some View {
+        GeometryReader { geo in
+            Group {
+                switch backgroundStyle {
+                case .solidColor(let color):
+                    Rectangle()
+                        .fill(color)
+
+                case .gradient(let colors, let startPoint, let endPoint):
+                    Rectangle()
+                        .fill(
+                            LinearGradient(
+                                colors: colors,
+                                startPoint: startPoint,
+                                endPoint: endPoint
+                            )
+                        )
+
+                case .image(let url):
+                    BackgroundImageView(url: url)
+                }
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+            .clipped()
+        }
+    }
+}
+
 /// Webcam overlay view for preview
 struct WebcamOverlayView: View {
     let frame: CIImage

--- a/EasyDemo/Views/WindowSelectionView.swift
+++ b/EasyDemo/Views/WindowSelectionView.swift
@@ -7,28 +7,27 @@
 
 import SwiftUI
 
-/// View for selecting a window to record
+/// View for selecting a source (window or display) to record
 struct WindowSelectionView: View {
-    @Binding var selectedWindow: WindowInfo?
+    @Binding var selectedSource: CaptureSource?
     @StateObject private var viewModel = WindowSelectionViewModel()
 
     var body: some View {
         VStack(spacing: 20) {
             // Header
             VStack(spacing: 8) {
-                Text("Select Window to Record")
+                Text("Select Source to Record")
                     .font(.title)
                     .fontWeight(.bold)
 
-                Text("Choose any window on your screen to start recording")
+                Text("Choose a window or screen to start recording")
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }
             .padding(.top, 30)
 
-            // Loading, permission check, or window list
+            // Loading, permission check, or source list
             if viewModel.windowCapture.isCheckingPermission {
-                // Show loading state while checking permissions
                 VStack(spacing: 16) {
                     ProgressView()
                         .scaleEffect(1.5)
@@ -40,7 +39,6 @@ struct WindowSelectionView: View {
                 }
                 .padding(40)
             } else if !viewModel.windowCapture.hasScreenRecordingPermission {
-                // Show permission request UI if denied
                 VStack(spacing: 16) {
                     Image(systemName: "exclamationmark.shield.fill")
                         .font(.system(size: 48))
@@ -49,43 +47,61 @@ struct WindowSelectionView: View {
                     Text("Screen Recording Permission Required")
                         .font(.headline)
 
-                    Text("Please grant screen recording permission to continue")
+                    Text("Grant screen recording permission in System Settings, then switch back here")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
 
-                    Button("Grant Permission") {
+                    Button("Open System Settings") {
                         Task {
-                            await viewModel.windowCapture.requestScreenRecordingPermission()
+                            await viewModel.requestPermissionAndLoadSources()
                         }
                     }
                     .buttonStyle(.borderedProminent)
                 }
                 .padding(40)
             } else {
-                // Window list or loading
-                if viewModel.isRefreshing && viewModel.windowCapture.availableWindows.isEmpty {
-                    // Show loading state while fetching windows for the first time
+                // Capture mode picker
+                Picker("Mode", selection: $viewModel.captureMode) {
+                    ForEach(WindowSelectionViewModel.CaptureMode.allCases, id: \.self) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+
+                if viewModel.isRefreshing && viewModel.windowCapture.availableWindows.isEmpty && viewModel.windowCapture.availableDisplays.isEmpty {
                     VStack(spacing: 16) {
                         ProgressView()
                             .scaleEffect(1.5)
                             .padding()
 
-                        Text("Loading windows...")
+                        Text("Loading sources...")
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                     }
                     .padding(40)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    // Window list
+                    // Source list
                     ScrollView {
                         LazyVStack(spacing: 12) {
-                            ForEach(viewModel.windowCapture.availableWindows) { window in
-                                WindowRowView(window: window, isSelected: selectedWindow?.id == window.id)
-                                    .onTapGesture {
-                                        selectedWindow = window
-                                    }
+                            if viewModel.captureMode == .windows {
+                                ForEach(viewModel.windowCapture.availableWindows) { window in
+                                    let source = CaptureSource.window(window)
+                                    WindowRowView(window: window, isSelected: selectedSource == source)
+                                        .onTapGesture {
+                                            selectedSource = source
+                                        }
+                                }
+                            } else {
+                                ForEach(viewModel.windowCapture.availableDisplays) { display in
+                                    let source = CaptureSource.display(display)
+                                    DisplayRowView(display: display, isSelected: selectedSource == source)
+                                        .onTapGesture {
+                                            selectedSource = source
+                                        }
+                                }
                             }
                         }
                         .padding(.horizontal)
@@ -96,10 +112,10 @@ struct WindowSelectionView: View {
                         Spacer()
                         Button {
                             Task {
-                                await viewModel.refreshWindows()
+                                await viewModel.refreshSources()
                             }
                         } label: {
-                            Label("Refresh Windows", systemImage: "arrow.clockwise")
+                            Label("Refresh", systemImage: "arrow.clockwise")
                         }
                         .disabled(viewModel.isRefreshing)
                     }
@@ -150,7 +166,7 @@ struct WindowRowView: View {
 
                 HStack(spacing: 12) {
                     Label(
-                        "\(Int(window.bounds.width)) × \(Int(window.bounds.height))",
+                        "\(Int(window.bounds.width)) x \(Int(window.bounds.height))",
                         systemImage: "arrow.up.left.and.arrow.down.right"
                     )
                     .font(.caption)
@@ -175,12 +191,68 @@ struct WindowRowView: View {
                 .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
         )
         .task {
-            // Defer thumbnail capture to avoid triggering screen access consent before recording
             thumbnail = nil
         }
     }
 }
 
+/// Row view for displaying display information
+struct DisplayRowView: View {
+    let display: DisplayInfo
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "display")
+                .font(.system(size: 24))
+                .foregroundColor(isSelected ? .white : .accentColor)
+                .frame(width: 80, height: 60)
+                .background(isSelected ? Color.accentColor : Color.accentColor.opacity(0.1))
+                .cornerRadius(8)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(display.displayName)
+                    .font(.headline)
+                    .foregroundColor(isSelected ? .white : .primary)
+                    .lineLimit(2)
+
+                HStack(spacing: 12) {
+                    Label(
+                        "\(display.width) x \(display.height)",
+                        systemImage: "arrow.up.left.and.arrow.down.right"
+                    )
+                    .font(.caption)
+
+                    if CGDisplayIsMain(display.id) != 0 {
+                        Text("Main")
+                            .font(.caption)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(isSelected ? Color.white.opacity(0.2) : Color.accentColor.opacity(0.1))
+                            .cornerRadius(4)
+                    }
+                }
+                .foregroundColor(isSelected ? .white.opacity(0.8) : .secondary)
+            }
+
+            Spacer()
+
+            if isSelected {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.title3)
+                    .foregroundColor(.white)
+            }
+        }
+        .padding()
+        .background(isSelected ? Color.accentColor : Color(.controlBackgroundColor))
+        .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+        )
+    }
+}
+
 #Preview {
-    WindowSelectionView(selectedWindow: .constant(nil))
+    WindowSelectionView(selectedSource: .constant(nil))
 }


### PR DESCRIPTION
Add ability to record full displays alongside individual windows.
Introduces CaptureSource model, display enumeration, segmented Windows/Screens picker, DisplayPreviewView, and rounded corner compositing for display captures.

Also, show a stop icon with elapsed time in the menu bar while recording. 

<img width="705" height="507" alt="image" src="https://github.com/user-attachments/assets/0fe0adaa-2007-43d5-8f00-38c203135f6f" />
